### PR TITLE
Update Hardware Store in zh-CN and zh-TW

### DIFF
--- a/src/assets/i18n/zh-CN.json
+++ b/src/assets/i18n/zh-CN.json
@@ -62,5 +62,6 @@
 	"Cosmetic Shop": "化妆品商店",
 	"Shrines and Temples": "神社和寺庙",
 	"Appliance Stores": "电器行",
-	"Curry Restaurant": "咖哩餐厅"
+	"Curry Restaurant": "咖哩餐厅",
+  "Hardware Store": "五金行"
 }

--- a/src/assets/i18n/zh-TW.json
+++ b/src/assets/i18n/zh-TW.json
@@ -62,5 +62,6 @@
 	"Cosmetic Shop": "化妝品商店",
 	"Shrines and Temples": "神社和寺廟",
 	"Appliance Stores": "電器行",
-	"Curry Restaurant": "咖哩餐廳"
+	"Curry Restaurant": "咖哩餐廳",
+  "Hardware Store": "五金行"
 }


### PR DESCRIPTION
Add Traditional Chinese (`zh-TW`) and Simplified Chinese (`zh-CN`) translations for Hardware Store.