### PR TITLE
fixed minor typos in the english About page

### DIFF
--- a/src/assets/markdown/about/about.en.md
+++ b/src/assets/markdown/about/about.en.md
@@ -4,7 +4,7 @@ This map gives clues to the likely locations of decorations in the game Pikmin B
 
 This application is not affiliated with Nintendo or Niantic Lab. The decoration category icons come from the game. This application is developed and maintained by [pixelpirate](https://pixelpirate.fr).
 
-## How does it works?
+## How does it work?
 
 To understand how this application works, you need to understand how the game determines the location of the decorations.
 
@@ -30,7 +30,8 @@ OSM does not have a function for directly retrieving objects for a particular ta
 ### Tips
 
 This application is designed to be pinned to your phone screen! To do this
+
 - On Android: Open your browser on your Android phone 🠖 Go to the address of this application 🠖 Press the icon with three dots at the top right of the screen and select "Add to home screen".
 - On iOS: Open Safari on your iPhone 🠖 Go to the address of this application 🠖 Press the share icon at the bottom of the screen and select "Add to home screen".
 
-These steps may sligthly vary from one phone to another.
+These steps may slightly vary from one phone to another.


### PR DESCRIPTION
Just fixing a couple tiny typos I saw on the English language's about page