### PR TITLE
Fixed typo in convenience store tag

### DIFF
--- a/src/assets/decors/decors.json
+++ b/src/assets/decors/decors.json
@@ -108,7 +108,7 @@
     "icon": "ConvenienceStore",
     "label": "Corner Store",
     "tags": [
-      "shop=onvenience"
+      "shop=convenience"
     ]
   },
   {


### PR DESCRIPTION
Hopefully rendering the convenience store icon rather than just the text 'Unknown Icon' on the map pin when searching for convenience store decor

(see also: issue #13 and my comment here https://github.com/pixlpirate/pikmin-map/issues/13#issuecomment-3652433781 on the visual difference that comes with this change)