### PR TITLE
Add debounce mechanism for overpass api

### DIFF
--- a/src/app/interfaces/decor-query.interface.ts
+++ b/src/app/interfaces/decor-query.interface.ts
@@ -1,0 +1,6 @@
+import { Decor } from "./decor.interface";
+
+export interface DecorQuery {
+	decors: Decor[];
+	bounds: [number, number, number, number];
+}

--- a/src/app/interfaces/index.ts
+++ b/src/app/interfaces/index.ts
@@ -1,5 +1,6 @@
 export * from './alert.interface';
 export * from './decor.interface';
+export * from './decor-query.interface';
 export * from './language.interface';
 export * from './local-map-data.interface';
 export * from './nominatim-result.interface';


### PR DESCRIPTION
It's fun to play with pikmin 

## Why
sometimes the overpass api got timeout or hit rate limit frequently
reduce the probability of "Too Many Request"

## Background
It should be network distance issue for the api host `https://overpass-api.de` with my hometown
It's easily to encounter the api error about "Gateway Timeout" or "Too Many Request"

## How
- Add DecorQuery to cache request parameter for decors and map bounds
- Add debounceTime and distinctUntilChanged to filter the events in short time
- debounceTime default duration is 300ms, maybe could be add to advanced option